### PR TITLE
Keep startup shortcut (e.g. when other javaw was used)

### DIFF
--- a/src/main/nsis/windows-setup.nsi
+++ b/src/main/nsis/windows-setup.nsi
@@ -78,10 +78,16 @@ CreateShortCut \
     "$JAVAEXE" '-jar "$INSTDIR\escape-from-intranet.jar"' \
    '$INSTDIR\online_ezx_icon.ico'
 
-CreateShortCut \
+# https://stackoverflow.com/questions/2099055/nsis-overwrites-shortcuts
+
+IfFileExists "$SMPROGRAMS\Startup\escape-from-intranet.lnk" SkipStartupShortcut
+
+  CreateShortCut \
    "$SMPROGRAMS\Startup\escape-from-intranet.lnk" \
     "$JAVAEXE" '-jar "$INSTDIR\escape-from-intranet.jar' \
    '$INSTDIR\online_ezx_icon.ico'
+
+SkipStartupShortcut:
 
 CreateShortCut \
    "$SMPROGRAMS\Quaddy Services\Uninstall escape-from-intranet.lnk" \


### PR DESCRIPTION
System has jdk8 as default and I want to run escapefromintranet with jdk11